### PR TITLE
Adiciona CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @apyb/diretoria @apyb/conselho-deliberativo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @pythonbrasil/diretoria @pythonbrasil/conselho-deliberativo
+*   @pythonbrasil/apyb @pythonbrasil/conselho-deliberativo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @apyb/diretoria @apyb/conselho-deliberativo
+*   @pythonbrasil/diretoria @pythonbrasil/conselho-deliberativo


### PR DESCRIPTION
Adiciona o grupo de diretores e o conselho deliberativo como CODEOWNERS do repositório.

Issue https://github.com/apyb/tarefas/issues/976